### PR TITLE
add log and other improvements

### DIFF
--- a/src/n2t/n2s.cpp
+++ b/src/n2t/n2s.cpp
@@ -27,6 +27,7 @@
 #include "n2t.h"
 #include "tcpsession.h"
 #include "udpsession.h"
+#include "utils.h"
 
 using namespace std;
 using namespace boost::asio;

--- a/src/n2t/n2s.cpp
+++ b/src/n2t/n2s.cpp
@@ -17,15 +17,17 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "n2s.h"
 #include <memory>
 #include <list>
 #include <boost/asio/io_service.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/asio/posix/stream_descriptor.hpp>
+
+#include "n2s.h"
 #include "n2t.h"
 #include "tcpsession.h"
 #include "udpsession.h"
+
 using namespace std;
 using namespace boost::asio;
 using namespace boost::asio::posix;
@@ -60,8 +62,13 @@ namespace Net2Tr {
             {
                 if (!error) {
                     char buf[2000];
-                    int len = read(fd.native_handle(), buf, sizeof(buf));
-                    n2t.input(string(buf, len));
+                    ssize_t len = read(fd.native_handle(), buf, sizeof(buf));
+                    if (len > 0) {
+                        n2t.input(string(buf, size_t(len)));
+                    } else {
+                        shutdown(fd.native_handle(), SHUT_RDWR);
+                        close(fd.native_handle());
+                    }
                 }
                 async_read_fd();
             });

--- a/src/n2t/socket.cpp
+++ b/src/n2t/socket.cpp
@@ -68,7 +68,7 @@ namespace Net2Tr {
                 if (packet.size() == 0) {
                     internal->end = true;
                 } else {
-                    tcp_recved(internal->pcb, packet.size());
+                    tcp_recved(internal->pcb, u16_t(packet.size()));
                     pbuf_free(p);
                 }
                 if (internal->recv) {
@@ -121,7 +121,7 @@ namespace Net2Tr {
     {
         internal->pending_len += packet.size();
         internal->sent = handler;
-        tcp_write(internal->pcb, packet.c_str(), packet.size(), TCP_WRITE_FLAG_COPY);
+        tcp_write(internal->pcb, packet.c_str(), u16_t(packet.size()), TCP_WRITE_FLAG_COPY);
         tcp_output(internal->pcb);
     }
 

--- a/src/n2t/tcpsession.cpp
+++ b/src/n2t/tcpsession.cpp
@@ -17,12 +17,14 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "tcpsession.h"
 #include <boost/asio/io_service.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/write.hpp>
+
+#include "tcpsession.h"
 #include "socket.h"
 #include "utils.h"
+
 using namespace std;
 using namespace boost::asio;
 using namespace boost::asio::ip;
@@ -73,6 +75,7 @@ namespace Net2Tr {
             out_sock.async_read_some(buffer(recv_buf, sizeof(recv_buf)), [this, self](const boost::system::error_code &error, size_t length)
             {
                 if (error) {
+                    N2T_LOG(error);
                     destroy();
                     return;
                 }
@@ -86,6 +89,7 @@ namespace Net2Tr {
             async_write(out_sock, buffer(data), [this, self](const boost::system::error_code &error, size_t)
             {
                 if (error) {
+                    N2T_LOG(error);
                     destroy();
                     return;
                 }
@@ -189,6 +193,7 @@ namespace Net2Tr {
         internal->out_sock.async_connect(tcp::endpoint(address::from_string(internal->socks5_addr), internal->socks5_port), [this, self](const boost::system::error_code &error)
         {
             if (error) {
+                N2T_LOG(error);
                 internal->destroy();
                 return;
             }

--- a/src/n2t/udpsession.cpp
+++ b/src/n2t/udpsession.cpp
@@ -68,6 +68,7 @@ namespace Net2Tr{
             tcp_sock.async_read_some(buffer(recv_buf, sizeof(recv_buf)), [this, self](const boost::system::error_code &error, size_t length)
             {
                 if (error) {
+                    N2T_LOG(error);
                     destroy();
                     return;
                 }
@@ -81,6 +82,7 @@ namespace Net2Tr{
             async_write(tcp_sock, buffer(data), [this, self](const boost::system::error_code &error, size_t)
             {
                 if (error) {
+                    N2T_LOG(error);
                     destroy();
                     return;
                 }
@@ -94,6 +96,7 @@ namespace Net2Tr{
             out_sock.async_receive(buffer(recv_buf, sizeof(recv_buf)), [this, self](const boost::system::error_code &error, size_t length)
             {
                 if (error) {
+                    N2T_LOG(error);
                     destroy();
                     return;
                 }
@@ -140,6 +143,7 @@ namespace Net2Tr{
                     }
                     out_sock.connect(udp::endpoint(address::from_string(addr), port), error);
                     if (error) {
+                        N2T_LOG(error);
                         destroy();
                         return;
                     }
@@ -232,6 +236,7 @@ namespace Net2Tr{
         internal->tcp_sock.async_connect(tcp::endpoint(address::from_string(internal->socks5_addr), internal->socks5_port), [this, self](const boost::system::error_code &error)
         {
             if (error) {
+                N2T_LOG(error);
                 internal->destroy();
                 return;
             }

--- a/src/n2t/udpsession.cpp
+++ b/src/n2t/udpsession.cpp
@@ -117,6 +117,7 @@ namespace Net2Tr{
 
         void tcp_recv(const string &data)
         {
+            boost::system::error_code error;
             switch (status) {
                 case HANDSHAKE:
                     if (data != string("\x05\x00", 2)) {
@@ -137,7 +138,11 @@ namespace Net2Tr{
                         destroy();
                         return;
                     }
-                    out_sock.connect(udp::endpoint(address::from_string(addr), port));
+                    out_sock.connect(udp::endpoint(address::from_string(addr), port), error);
+                    if (error) {
+                        destroy();
+                        return;
+                    }
                     status = FORWARD;
                     tcp_async_read();
                     out_async_read();

--- a/src/n2t/utils.cpp
+++ b/src/n2t/utils.cpp
@@ -94,4 +94,11 @@ namespace Net2Tr {
             return -1;
         }
     }
+
+    void Utils::log(const char *file, const char *func, int line, const std::string &msg) {
+#if defined(ANDROID) || defined(__ANDROID__)
+        __android_log_print(ANDROID_LOG_ERROR, "libn2t", "%s:%d %s(): %s\n",
+                            file, line, func, msg.c_str());
+#endif
+    }
 }

--- a/src/n2t/utils.cpp
+++ b/src/n2t/utils.cpp
@@ -27,10 +27,10 @@ using namespace boost::asio::ip;
 namespace Net2Tr {
     pbuf *Utils::str_to_pbuf(const string &str)
     {
-        pbuf *p = pbuf_alloc(PBUF_RAW, str.size(), PBUF_POOL);
+        pbuf *p = pbuf_alloc(PBUF_RAW, u16_t(str.size()), PBUF_POOL);
         if (p == NULL)
             return NULL;
-        pbuf_take(p, str.c_str(), str.size());
+        pbuf_take(p, str.c_str(), u16_t(str.size()));
         return p;
     }
 

--- a/src/n2t/utils.h
+++ b/src/n2t/utils.h
@@ -20,7 +20,21 @@
 #ifndef _N2T_UTILS_H_
 #define _N2T_UTILS_H_
 
+#include <cstdio>
 #include <string>
+
+#if defined(ANDROID) || defined(__ANDROID__)
+#include <android/log.h>
+#define N2T_LOG(error_code)                                                     \
+    do {                                                                        \
+        if (error_code.value() != boost::asio::error::operation_aborted         \
+            && error_code.value() != boost::asio::error::eof) {                 \
+            Utils::log(__FILE__, __func__, __LINE__, error_code.message());     \
+        }                                                                       \
+    } while(0)
+#else
+#define N2T_LOG(error_code)
+#endif
 
 struct pbuf;
 
@@ -31,6 +45,7 @@ namespace Net2Tr {
         static std::string pbuf_to_str(pbuf *p);
         static std::string addrport_to_socks5(const std::string &addr, uint16_t port);
         static int socks5_to_addrport(const std::string &socks5, std::string &addr, uint16_t &port);
+        static void log(const char *file, const char *func, int line, const std::string &msg);
     };
 }
 


### PR DESCRIPTION
- log facility for Android, output file name, function name and line number
- refine type mismatch warning
- add error checking when reading from fd

Signed-off-by: Syrone Wong <wong.syrone@gmail.com>

To test this on igniter, apply the patch below

```patch
diff --git a/app/src/main/cpp/CMakeLists.txt b/app/src/main/cpp/CMakeLists.txt
index 637702e..9861038 100644
--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required(VERSION 3.6)
 project(igniter)
+find_library( # Sets the name of the path variable.
+          androidLogLib
+
+          # Specifies the name of the NDK library that
+          # you want CMake to locate.
+          log)
 add_library(trojan
     trojan/src/authenticator.cpp
     trojan/src/clientsession.cpp
@@ -72,7 +78,9 @@ target_include_directories(n2t PRIVATE
     ${CMAKE_SOURCE_DIR}/libn2t/src/custom
     ${CMAKE_SOURCE_DIR}/libn2t/src/lwip/src/include
     ${CMAKE_SOURCE_DIR}/libs/include)
-target_link_libraries(n2t ${CMAKE_SOURCE_DIR}/libs/lib/${ANDROID_ABI}/libboost_system.a)
+target_link_libraries(n2t
+    ${CMAKE_SOURCE_DIR}/libs/lib/${ANDROID_ABI}/libboost_system.a
+    ${androidLogLib})
 add_library(jni-helper SHARED jni-helper.cpp)
 target_include_directories(jni-helper PRIVATE
     ${CMAKE_SOURCE_DIR}/trojan/src
```