### PR TITLE
fix resource leaks and other refinements

### DIFF
--- a/src/n2t/n2t.cpp
+++ b/src/n2t/n2t.cpp
@@ -48,6 +48,17 @@ namespace Net2Tr {
         {
             init();
         }
+        ~N2TInternal() {
+            if (upcb != NULL) {
+                udp_remove(upcb);
+                upcb = NULL;
+            }
+            if (listen_pcb != NULL) {
+                tcp_close(listen_pcb);
+                listen_pcb = NULL;
+            }
+            netif_remove(&ni);
+        }
 
         static void init()
         {
@@ -151,10 +162,10 @@ namespace Net2Tr {
 
     N2T::~N2T()
     {
-        udp_remove(internal->upcb);
-        tcp_close(internal->listen_pcb);
-        netif_remove(&internal->ni);
-        delete internal;
+        if (internal != NULL) {
+            delete internal;
+            internal = NULL;
+        }
     }
 
     void N2T::input(const string &packet)

--- a/src/n2t/n2t.cpp
+++ b/src/n2t/n2t.cpp
@@ -54,7 +54,9 @@ namespace Net2Tr {
                 upcb = NULL;
             }
             if (listen_pcb != NULL) {
-                tcp_close(listen_pcb);
+                if (ERR_OK != tcp_close(listen_pcb)) {
+                    tcp_abort(listen_pcb);
+                }
                 listen_pcb = NULL;
             }
             netif_remove(&ni);

--- a/src/n2t/socket.cpp
+++ b/src/n2t/socket.cpp
@@ -38,15 +38,13 @@ namespace Net2Tr {
 
         SocketInternal() : pcb(NULL), pending_len(0), end(false), erred(false) {}
         ~SocketInternal() {
-            if (pcb != NULL) {
+            if (pcb != NULL && !erred) {
+                // lwip tcp_err_fn: The corresponding pcb is already freed when this callback is called!
                 // unregister callbacks
                 tcp_recv(pcb, NULL);
                 tcp_sent(pcb, NULL);
                 tcp_err(pcb, NULL);
-                // lwip tcp_err_fn: The corresponding pcb is already freed when this callback is called!
-                if (!erred) {
-                    tcp_close(pcb);
-                }
+                tcp_close(pcb);
 
                 pcb = NULL;
             }

--- a/src/n2t/socket.cpp
+++ b/src/n2t/socket.cpp
@@ -44,7 +44,9 @@ namespace Net2Tr {
                 tcp_recv(pcb, NULL);
                 tcp_sent(pcb, NULL);
                 tcp_err(pcb, NULL);
-                tcp_close(pcb);
+                if (ERR_OK != tcp_close(pcb)) {
+                    tcp_abort(pcb);
+                }
 
                 pcb = NULL;
             }

--- a/src/n2t/socket.h
+++ b/src/n2t/socket.h
@@ -27,8 +27,8 @@
 struct tcp_pcb;
 
 namespace Net2Tr {
-    typedef std::function<void(const std::string &packet)> RecvHandler;
-    typedef std::function<void()> SentHandler;
+    typedef std::function<void(bool pcb_freed, const std::string &packet)> RecvHandler;
+    typedef std::function<void(bool pcb_freed)> SentHandler;
     typedef std::function<void(int8_t err)> ErrHandler;
 
     class Socket {

--- a/src/n2t/tcpsession.cpp
+++ b/src/n2t/tcpsession.cpp
@@ -54,9 +54,9 @@ namespace Net2Tr {
         void in_async_read()
         {
             auto self = session.shared_from_this();
-            in_sock.async_recv([this, self](const string &packet)
+            in_sock.async_recv([this, self](bool pcb_freed, const string &packet)
             {
-                if (packet.size() == 0) {
+                if (pcb_freed) {
                     destroy();
                     return;
                 }
@@ -67,8 +67,12 @@ namespace Net2Tr {
         void in_async_write(const string &data)
         {
             auto self = session.shared_from_this();
-            in_sock.async_send(data, [this, self]()
+            in_sock.async_send(data, [this, self](bool pcb_freed)
             {
+                if (pcb_freed) {
+                    destroy();
+                    return;
+                }
                 in_sent();
             });
         }

--- a/src/n2t/tcpsession.cpp
+++ b/src/n2t/tcpsession.cpp
@@ -45,8 +45,12 @@ namespace Net2Tr {
         tcp::socket out_sock;
         char recv_buf[8192];
 
-        TCPSessionInternal(TCPSession &session, io_service &service, const string &socks5_addr, uint16_t socks5_port) : status(HANDSHAKE), session(session), socks5_addr(socks5_addr), socks5_port(socks5_port), out_sock(service) {}
+        TCPSessionInternal(TCPSession &session, io_service &service, const string &socks5_addr, uint16_t socks5_port)
+        : status(HANDSHAKE), session(session), socks5_addr(socks5_addr), socks5_port(socks5_port), out_sock(service) {}
 
+        ~TCPSessionInternal() {
+            destroy();
+        }
         void in_async_read()
         {
             auto self = session.shared_from_this();
@@ -175,7 +179,10 @@ namespace Net2Tr {
 
     TCPSession::~TCPSession()
     {
-        delete internal;
+        if (internal != NULL) {
+            delete internal;
+            internal = NULL;
+        }
     }
 
     Socket *TCPSession::socket()

--- a/src/n2t/udpsession.cpp
+++ b/src/n2t/udpsession.cpp
@@ -49,7 +49,12 @@ namespace Net2Tr{
         list<UDPPacket> send_que;
         WriteUDP in_write;
 
-        UDPSessionInternal(UDPSession &session, io_service &service, const string &socks5_addr, uint16_t socks5_port, const UDPPacket &initial_packet, WriteUDP write_udp) : status(HANDSHAKE), session(session), socks5_addr(socks5_addr), socks5_port(socks5_port), out_sock(service), tcp_sock(service), gc_timer(service), initial_packet(initial_packet), in_write(write_udp) {}
+        UDPSessionInternal(UDPSession &session, io_service &service, const string &socks5_addr, uint16_t socks5_port, const UDPPacket &initial_packet, WriteUDP write_udp)
+        : status(HANDSHAKE), session(session), socks5_addr(socks5_addr), socks5_port(socks5_port),
+        out_sock(service), tcp_sock(service), gc_timer(service), initial_packet(initial_packet), in_write(write_udp) {}
+        ~UDPSessionInternal() {
+            destroy();
+        }
 
         void async_wait_timer()
         {
@@ -226,7 +231,10 @@ namespace Net2Tr{
 
     UDPSession::~UDPSession()
     {
-        delete internal;
+        if (internal != NULL) {
+            delete internal;
+            internal = NULL;
+        }
     }
 
     void UDPSession::start()


### PR DESCRIPTION
- enforce tun_fd naming to make it more clear
- add stopped state to stop calling recursively
- enlarge read buffer to 2048
- do NOT close tun_fd in libn2t, it should be done on Android side,
  just log it since it's a rare case
- cancel socket should unregister callbacks as well
- move most of resource cleanup work into internal class destructor,
  including N2TInternal, SocketInternal
- call resource cleanup in destructor as well,
  including TCPSessionInternal, UDPSessionInternal

Signed-off-by: Syrone Wong <wong.syrone@gmail.com>